### PR TITLE
chore(processor): improve handling of modification amount

### DIFF
--- a/processor/src/dtos/operations/payment-intents.dto.ts
+++ b/processor/src/dtos/operations/payment-intents.dto.ts
@@ -1,8 +1,8 @@
 import { Static, Type } from '@sinclair/typebox';
 
 export const AmountSchema = Type.Object({
-  amount: Type.Integer(),
-  currency: Type.String(),
+  centAmount: Type.Integer(),
+  currencyCode: Type.String(),
 });
 
 export const ActionCapturePaymentSchema = Type.Composite([

--- a/processor/src/services/operation.service.ts
+++ b/processor/src/services/operation.service.ts
@@ -53,6 +53,8 @@ export class DefaultOperationService implements OperationService {
     let requestAmount!: AmountSchemaDTO;
     if (request.action != 'cancelPayment') {
       requestAmount = request.amount;
+    } else {
+      requestAmount = ctPayment.amountPlanned;
     }
 
     const transactionType = this.getPaymentTransactionType(request.action);
@@ -61,7 +63,7 @@ export class DefaultOperationService implements OperationService {
       id: ctPayment.id,
       transaction: {
         type: transactionType,
-        amount: ctPayment.amountPlanned,
+        amount: requestAmount,
         state: 'Initial',
       },
     });
@@ -72,7 +74,7 @@ export class DefaultOperationService implements OperationService {
       id: ctPayment.id,
       transaction: {
         type: transactionType,
-        amount: ctPayment.amountPlanned,
+        amount: requestAmount,
         interactionId: res?.pspReference,
         state: res.outcome === PaymentModificationStatus.APPROVED ? 'Success' : 'Failure',
       },


### PR DESCRIPTION
With this change, we create a transaction with the actual amount in the modification request, except in the case of a `cancelPayment` request where we send the total amount.

Furthermore, the `AmountSchema` is changed in this PR to match what coco supports. Each connector should handle converting the amount value to what the PSP expects.