### PR TITLE
feat(payments): added support for retrieving the merchant url from the session

### DIFF
--- a/processor/.env.template
+++ b/processor/.env.template
@@ -6,7 +6,6 @@ CTP_CLIENT_ID=[composable-commerce-client-id]
 CTP_CLIENT_SECRET=[composable-commerce-client-secret]
 CTP_PROJECT_KEY=[composable-commerce-project-key]
 
-# Merchant website
-SELLER_RETURN_URL=[Merchant-website-return-url]
-SELLER_SEND_NOTIFICATION_ENABLED=[true/false]
-SELLER_NOTIFICATION_URL=[Merchant-website-return-url]
+# Merchant return URL for redirecting the user back to the merchant website after the payment is completed
+# Use it as a fallback if no merchantReturnUrl is provided in the session
+MERCHANT_RETURN_URL=[Merchant-website-return-url]

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@commercetools-backend/loggers": "22.20.0",
-        "@commercetools/connect-payments-sdk": "0.2.0",
+        "@commercetools/connect-payments-sdk": "0.3.0",
         "@commercetools/platform-sdk": "7.4.0",
         "@commercetools/sdk-client-v2": "2.3.0",
         "@fastify/autoload": "5.8.0",
@@ -596,28 +596,14 @@
       }
     },
     "node_modules/@commercetools/connect-payments-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.2.0.tgz",
-      "integrity": "sha512-rizAV6qjCxWDI0enCexs7qi70Bi7EuYU7twpHffRBlDmD1fdfBFgEAsAaKC5q5+resVm8xjB2scUA8L0ZKaz3g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.3.0.tgz",
+      "integrity": "sha512-Oc8vISVDJY3VpnoV0PbQKgVi08MmPkotYchRiyvzFzxuvQv2YLBrhV7N9vLtRgC2J9y3oekECFRaiqzAsx7ZdQ==",
       "dependencies": {
-        "@commercetools/platform-sdk": "7.3.0",
+        "@commercetools/platform-sdk": "7.4.0",
         "@commercetools/sdk-client-v2": "2.3.0",
         "jsonwebtoken": "9.0.2",
         "jwks-rsa": "3.1.0"
-      }
-    },
-    "node_modules/@commercetools/connect-payments-sdk/node_modules/@commercetools/platform-sdk": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-7.3.0.tgz",
-      "integrity": "sha512-MovSWsEk8f/ZwtxHPuYf8dMIf3R3bOU44UdKtha4JXWw/xrP03B0/MlEPnmHskGHedb2QMt2asvEfw2yLF34oA==",
-      "dependencies": {
-        "@commercetools/sdk-client-v2": "^2.2.2",
-        "@commercetools/sdk-middleware-auth": "^7.0.0",
-        "@commercetools/sdk-middleware-http": "^7.0.0",
-        "@commercetools/sdk-middleware-logger": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@commercetools/platform-sdk": {
@@ -10021,27 +10007,14 @@
       }
     },
     "@commercetools/connect-payments-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.2.0.tgz",
-      "integrity": "sha512-rizAV6qjCxWDI0enCexs7qi70Bi7EuYU7twpHffRBlDmD1fdfBFgEAsAaKC5q5+resVm8xjB2scUA8L0ZKaz3g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.3.0.tgz",
+      "integrity": "sha512-Oc8vISVDJY3VpnoV0PbQKgVi08MmPkotYchRiyvzFzxuvQv2YLBrhV7N9vLtRgC2J9y3oekECFRaiqzAsx7ZdQ==",
       "requires": {
-        "@commercetools/platform-sdk": "7.3.0",
+        "@commercetools/platform-sdk": "7.4.0",
         "@commercetools/sdk-client-v2": "2.3.0",
         "jsonwebtoken": "9.0.2",
         "jwks-rsa": "3.1.0"
-      },
-      "dependencies": {
-        "@commercetools/platform-sdk": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-7.3.0.tgz",
-          "integrity": "sha512-MovSWsEk8f/ZwtxHPuYf8dMIf3R3bOU44UdKtha4JXWw/xrP03B0/MlEPnmHskGHedb2QMt2asvEfw2yLF34oA==",
-          "requires": {
-            "@commercetools/sdk-client-v2": "^2.2.2",
-            "@commercetools/sdk-middleware-auth": "^7.0.0",
-            "@commercetools/sdk-middleware-http": "^7.0.0",
-            "@commercetools/sdk-middleware-logger": "^3.0.0"
-          }
-        }
       }
     },
     "@commercetools/platform-sdk": {

--- a/processor/package.json
+++ b/processor/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "@commercetools-backend/loggers": "22.20.0",
-    "@commercetools/connect-payments-sdk": "0.2.0",
+    "@commercetools/connect-payments-sdk": "0.3.0",
     "@commercetools/platform-sdk": "7.4.0",
     "@commercetools/sdk-client-v2": "2.3.0",
     "@fastify/autoload": "5.8.0",

--- a/processor/src/libs/fastify/context/context.ts
+++ b/processor/src/libs/fastify/context/context.ts
@@ -32,6 +32,11 @@ export const updateRequestContext = (ctx: Partial<ContextData>) => {
   });
 };
 
+export const getCtSessionIdFromContext = (): string => {
+  const authentication = getRequestContext().authentication as SessionAuthentication;
+  return authentication?.getCredentials();
+};
+
 export const getCartIdFromContext = (): string => {
   const authentication = getRequestContext().authentication as SessionAuthentication;
   return authentication?.getPrincipal().cartId;
@@ -50,6 +55,11 @@ export const getPaymentInterfaceFromContext = (): string | undefined => {
 export const getProcessorUrlFromContext = (): string => {
   const authentication = getRequestContext().authentication as SessionAuthentication;
   return authentication?.getPrincipal().processorUrl;
+};
+
+export const getMerchantReturnUrlFromContext = (): string | undefined => {
+  const authentication = getRequestContext().authentication as SessionAuthentication;
+  return authentication?.getPrincipal().merchantReturnUrl;
 };
 
 export const requestContextPlugin = fp(async (fastify: FastifyInstance) => {

--- a/processor/src/routes/mock-payment.route.ts
+++ b/processor/src/routes/mock-payment.route.ts
@@ -1,4 +1,4 @@
-import { SessionAuthenticationHook } from '@commercetools/connect-payments-sdk';
+import { SessionHeaderAuthenticationHook } from '@commercetools/connect-payments-sdk';
 import { FastifyInstance, FastifyPluginOptions } from 'fastify';
 import {
   PaymentRequestSchema,
@@ -10,14 +10,14 @@ import { MockPaymentService } from '../services/mock-payment.service';
 
 type PaymentRoutesOptions = {
   paymentService: MockPaymentService;
-  sessionAuthHook: SessionAuthenticationHook;
+  sessionHeaderAuthHook: SessionHeaderAuthenticationHook;
 };
 
 export const paymentRoutes = async (fastify: FastifyInstance, opts: FastifyPluginOptions & PaymentRoutesOptions) => {
   fastify.post<{ Body: PaymentRequestSchemaDTO; Reply: PaymentResponseSchemaDTO }>(
     '/payments',
     {
-      preHandler: [opts.sessionAuthHook.authenticate()],
+      preHandler: [opts.sessionHeaderAuthHook.authenticate()],
       schema: {
         body: PaymentRequestSchema,
         response: {

--- a/processor/src/routes/operation.route.ts
+++ b/processor/src/routes/operation.route.ts
@@ -2,7 +2,7 @@ import {
   AuthorityAuthorizationHook,
   JWTAuthenticationHook,
   Oauth2AuthenticationHook,
-  SessionAuthenticationHook,
+  SessionHeaderAuthenticationHook,
 } from '@commercetools/connect-payments-sdk';
 import { Type } from '@sinclair/typebox';
 import { FastifyInstance, FastifyPluginOptions } from 'fastify';
@@ -18,7 +18,7 @@ import { StatusResponseSchema, StatusResponseSchemaDTO } from '../dtos/operation
 import { AbstractPaymentService } from '../services/abstract-payment.service';
 
 type OperationRouteOptions = {
-  sessionAuthHook: SessionAuthenticationHook;
+  sessionHeaderAuthHook: SessionHeaderAuthenticationHook;
   oauth2AuthHook: Oauth2AuthenticationHook;
   jwtAuthHook: JWTAuthenticationHook;
   authorizationHook: AuthorityAuthorizationHook;
@@ -29,7 +29,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
   fastify.get<{ Reply: ConfigResponseSchemaDTO }>(
     '/config',
     {
-      preHandler: [opts.sessionAuthHook.authenticate()],
+      preHandler: [opts.sessionHeaderAuthHook.authenticate()],
       schema: {
         response: {
           200: ConfigResponseSchema,

--- a/processor/src/server/plugins/mock-payment.plugin.ts
+++ b/processor/src/server/plugins/mock-payment.plugin.ts
@@ -11,6 +11,6 @@ export default async function (server: FastifyInstance) {
 
   await server.register(paymentRoutes, {
     paymentService: mockPaymentService,
-    sessionAuthHook: paymentSDK.sessionAuthHookFn,
+    sessionHeaderAuthHook: paymentSDK.sessionHeaderAuthHookFn,
   });
 }

--- a/processor/src/server/plugins/operation.plugin.ts
+++ b/processor/src/server/plugins/operation.plugin.ts
@@ -9,7 +9,7 @@ export default async function (server: FastifyInstance) {
     paymentService: app.services.paymentService,
     jwtAuthHook: paymentSDK.jwtAuthHookFn,
     oauth2AuthHook: paymentSDK.oauth2AuthHookFn,
-    sessionAuthHook: paymentSDK.sessionAuthHookFn,
+    sessionHeaderAuthHook: paymentSDK.sessionHeaderAuthHookFn,
     authorizationHook: paymentSDK.authorityAuthorizationHookFn,
   });
 }


### PR DESCRIPTION
This pull request includes changes primarily focused on :
- adding support for retrieving the merchant return url from the session so that the same connector instance can be reused for different websites
- updating the `@commercetools/connect-payments-sdk` library version and its usage in the `processor` package. The updated version changed the `SessionAuthenticationHook` to `SessionHeaderAuthenticationHook`, leading to modifications in several files. Additionally, there are changes in the `.env.template` file to improve the clarity of merchant return URL usage. 

