### PR TITLE
Update card validations and handle failure case for card payment

### DIFF
--- a/enabler/src/components/payment-methods/card/card.ts
+++ b/enabler/src/components/payment-methods/card/card.ts
@@ -64,20 +64,20 @@ export class Card extends BaseComponent {
 
       // Mock Validation
       let isAuthorized = this.isCreditCardAllowed(requestData.paymentMethod.cardNumber);
-
       const resultCode = isAuthorized ? PaymentOutcome.AUTHORIZED : PaymentOutcome.REJECTED;
 
-      if (resultCode === PaymentOutcome.AUTHORIZED) {
-        const request: PaymentRequestSchemaDTO = {
-          paymentMethod: this.paymentMethod
-        }
-        const response = await fetch(this.processorUrl + '/payments', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Session-Id': this.sessionId },
-          body: JSON.stringify(request),
-        });
-        const data = await response.json();
+      const request: PaymentRequestSchemaDTO = {
+        paymentMethod: this.paymentMethod,
+        paymentOutcome: resultCode
+      }
+      const response = await fetch(this.processorUrl + '/payments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Session-Id': this.sessionId },
+        body: JSON.stringify(request),
+      });
+      const data = await response.json();
 
+      if (resultCode === PaymentOutcome.AUTHORIZED) {
         this.onComplete && this.onComplete({ isSuccess: true, paymentReference: data.paymentReference });
       } else {
         this.onComplete && this.onComplete({ isSuccess: false });
@@ -92,6 +92,7 @@ export class Card extends BaseComponent {
     return `
     <div class="${styles.wrapper}">
       <form class="${styles.paymentForm}">
+        <div class="${inputFieldStyles.inputContainer}"> * Required fields for payment by credit card </div>
         <div class="${inputFieldStyles.inputContainer}">
           <label class="${inputFieldStyles.inputLabel}" for="creditCardForm.cardNumber">
             Card number <span aria-hidden="true"> *</span>

--- a/enabler/src/components/payment-methods/card/utils.ts
+++ b/enabler/src/components/payment-methods/card/utils.ts
@@ -52,11 +52,11 @@ const isFieldValid = (field: string) => {
   const input = getInput(field);
   switch (field) {
     case 'creditCardForm-cardNumber':
-      return input.value.replace(/\s/g, '').length === 16;
+      return input.value.replace(/\s/g, '').length >= 15;
     case 'creditCardForm-expiryDate':
       return input.value.length === 5;
     case 'creditCardForm-cvv':
-      return input.value.length === 3;
+      return input.value.length === 3 || input.value.length === 4;
     case 'creditCardForm-holderNameLabel':
       return input.value.length > 0;
     default:
@@ -161,7 +161,12 @@ const addCvvEventListeners = () => {
     if (isNaN(Number(cvv.value))) {
       cvv.value = cvv.value.slice(0, -1);
     }
-    if (cvv.value.length > 3) {
+    const cardNumber = getInput(fieldIds.cardNumber);
+    const brand = getCardBrand(cardNumber.value);
+    if (brand === 'amex' && cvv.value.length > 4) {
+      cvv.value = cvv.value.slice(0, 4);
+    }
+    if (brand !== 'amex' && cvv.value.length > 3) {
       cvv.value = cvv.value.slice(0, 3);
     }
   });

--- a/enabler/src/components/payment-methods/card/utils.ts
+++ b/enabler/src/components/payment-methods/card/utils.ts
@@ -52,7 +52,13 @@ const isFieldValid = (field: string) => {
   const input = getInput(field);
   switch (field) {
     case 'creditCardForm-cardNumber':
-      return input.value.replace(/\s/g, '').length >= 15;
+      const cardNumber = getInput(fieldIds.cardNumber);
+      const brand = getCardBrand(cardNumber.value);
+      if(brand === 'amex') {
+        return input.value.replace(/\s/g, '').length === 15;
+      } else {
+        return input.value.replace(/\s/g, '').length === 16;
+      }
     case 'creditCardForm-expiryDate':
       return input.value.length === 5;
     case 'creditCardForm-cvv':

--- a/enabler/src/dtos/mock-payment.dto.ts
+++ b/enabler/src/dtos/mock-payment.dto.ts
@@ -1,12 +1,15 @@
 import { Static, Type } from '@sinclair/typebox';
 
-export const PaymentRequestSchema = Type.Object({
-  paymentMethod: Type.String(),
-});
-
 export enum PaymentOutcome {
   AUTHORIZED = 'Authorized',
   REJECTED = 'Rejected',
 }
+
+export const PaymentOutcomeSchema = Type.Enum(PaymentOutcome);
+
+export const PaymentRequestSchema = Type.Object({
+  paymentMethod: Type.String(),
+  paymentOutcome: PaymentOutcomeSchema,
+});
 
 export type PaymentRequestSchemaDTO = Static<typeof PaymentRequestSchema>;

--- a/processor/src/dtos/mock-payment.dto.ts
+++ b/processor/src/dtos/mock-payment.dto.ts
@@ -1,9 +1,5 @@
 import { Static, Type } from '@sinclair/typebox';
 
-export const PaymentRequestSchema = Type.Object({
-  paymentMethod: Type.String(),
-});
-
 export enum PaymentOutcome {
   AUTHORIZED = 'Authorized',
   REJECTED = 'Rejected',
@@ -11,6 +7,13 @@ export enum PaymentOutcome {
 
 export const PaymentResponseSchema = Type.Object({
   paymentReference: Type.String(),
+});
+
+export const PaymentOutcomeSchema = Type.Enum(PaymentOutcome);
+
+export const PaymentRequestSchema = Type.Object({
+  paymentMethod: Type.String(),
+  paymentOutcome: PaymentOutcomeSchema,
 });
 
 export type PaymentRequestSchemaDTO = Static<typeof PaymentRequestSchema>;

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -205,7 +205,7 @@ export class MockPaymentService extends AbstractPaymentService {
         type: 'Authorization',
         amount: ctPayment.amountPlanned,
         interactionId: pspReference,
-        state: this.convertPaymentResultCode(PaymentOutcome.AUTHORIZED),
+        state: this.convertPaymentResultCode(request.data.paymentOutcome),
       },
     });
 

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -13,6 +13,7 @@ import * as FastifyContext from '../src/libs/fastify/context/context';
 import * as StatusHandler from '@commercetools/connect-payments-sdk/dist/api/handlers/status.handler';
 
 import { HealthCheckResult } from '@commercetools/connect-payments-sdk';
+import {PaymentOutcome} from "../src/dtos/mock-payment.dto";
 
 interface FlexibleConfig {
   [key: string]: string; // Adjust the type according to your config values
@@ -167,6 +168,7 @@ describe('mock-payment.service', () => {
     const createPaymentOpts: CreatePaymentRequest = {
       data: {
         paymentMethod: 'card',
+        paymentOutcome: PaymentOutcome.AUTHORIZED,
       },
     };
     jest.spyOn(DefaultCartService.prototype, 'getCart').mockReturnValue(Promise.resolve(mockGetCartResult()));
@@ -183,6 +185,7 @@ describe('mock-payment.service', () => {
     const createPaymentOpts: CreatePaymentRequest = {
       data: {
         paymentMethod: 'invoice',
+        paymentOutcome: PaymentOutcome.AUTHORIZED,
       },
     };
     jest.spyOn(DefaultCartService.prototype, 'getCart').mockReturnValue(Promise.resolve(mockGetCartResult()));


### PR DESCRIPTION
- Update Card card validations
 1) AMEX cards have only 15 numbers.
 2) CVV should be allowed to enter 4 numbers

- Handle card validation failure case, Send request to Processor to create the Payment with Failure payment validation.
