### PR TITLE
fix(components): fixed label overlaps with input value

### DIFF
--- a/enabler/src/components/payment-methods/card/utils.ts
+++ b/enabler/src/components/payment-methods/card/utils.ts
@@ -40,6 +40,9 @@ export const validateAllFields = () => {
 const handleFieldValidation = (field: string) => {
   const input = getInput(field);
   input.addEventListener('input', () => {
+    input.value.length > 0
+      ? input.parentElement.classList.add(inputFieldStyles.containValue)
+      : input.parentElement.classList.remove(inputFieldStyles.containValue);
     hideErrorIfValid(field);
   });
   input.addEventListener('focusout', () => {

--- a/enabler/src/components/payment-methods/purchase-order/purchase-order.ts
+++ b/enabler/src/components/payment-methods/purchase-order/purchase-order.ts
@@ -128,6 +128,7 @@ export class PurchaseOrder extends BaseComponent {
 
   private addFormFieldsEventListeners = () => {
     this.handleFieldValidation(this.poNumberId);
+    this.handleFieldFocusOut(this.invoiceMemoId);
   };
 
   private getInput(field: string): HTMLInputElement {
@@ -172,13 +173,25 @@ export class PurchaseOrder extends BaseComponent {
   private handleFieldValidation(field: string) {
     const input = this.getInput(field);
     input.addEventListener("input", () => {
+      this.manageLabelClass(input);
       this.hideErrorIfValid(field);
     });
     input.addEventListener("focusout", () => {
       this.showErrorIfInvalid(field);
-      input.value.length > 0
-        ? input.parentElement.classList.add(inputFieldStyles.containValue)
-        : input.parentElement.classList.remove(inputFieldStyles.containValue);
+      this.manageLabelClass(input);
     });
   }
+
+  private handleFieldFocusOut(field: string) {
+    const input = this.getInput(field);
+    input.addEventListener("focusout", () => {
+      this.manageLabelClass(input);
+    });
+  }
+
+  private manageLabelClass = (input: HTMLInputElement) => {
+    input.value.length > 0
+      ? input.parentElement.classList.add(inputFieldStyles.containValue)
+      : input.parentElement.classList.remove(inputFieldStyles.containValue);
+  };
 }


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2536

Fixed issue with the label styling in the inputs. The problem was affecting `card` and `purchaseorder` components: 
- When the user selects a saved card, the saved data for the fields  "CVV", and "Card Name" overlaps with the placeholders in the form fields. This makes it appear as though the fields are empty.
- It also happens in Invoice Memo field in Purchase Order (PO) payment method.