### PR TITLE
feat(operations): add transaction API operation

### DIFF
--- a/processor/package.json
+++ b/processor/package.json
@@ -12,6 +12,7 @@
     "dev": "ts-node src/main.ts",
     "watch": "nodemon --watch \"src/**\" --ext \"ts,json\" --ignore \"src/**/*.spec.ts\" --exec \"ts-node src/main.ts\"",
     "test": "jest --detectOpenHandles",
+    "test:watch": "jest --watch --detectOpenHandles",
     "connector:post-deploy": "node dist/connectors/post-deploy.js",
     "connector:pre-undeploy": "node dist/connectors/pre-undeploy.js"
   },

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -10,7 +10,24 @@ export const TransactionDraft = Type.Object({
     }),
   ),
 });
-export const TransactionStatusState = Type.Union([Type.Literal('Pending'), Type.Literal('Failed')]);
+
+const TransactionStatePending = Type.Literal('Pending', {
+  description: 'The authorization/capture has not happened yet. Most likely because we need to receive notification.',
+});
+
+const TransactionStateFailed = Type.Literal('Failed', {
+  description: "Any error that occured for which the system can't recover automatically from.",
+});
+
+const TransactionStateComplete = Type.Literal('Complete', {
+  description: 'If there is a successful authorization/capture on the payment-transaction.',
+});
+
+export const TransactionStatusState = Type.Union([
+  TransactionStateComplete,
+  TransactionStateFailed,
+  TransactionStatePending,
+]);
 
 export const TransactionResponse = Type.Object({
   transactionStatus: Type.Object({

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -1,0 +1,28 @@
+import { Static, Type } from '@sinclair/typebox';
+
+export const TransactionDraft = Type.Object({
+  cartId: Type.String({ format: 'uuid' }),
+  paymentInterface: Type.String({ format: 'uuid' }),
+  amount: Type.Optional(
+    Type.Object({
+      centAmount: Type.Number(),
+      currencyCode: Type.String(),
+    }),
+  ),
+});
+export const TransactionStatusState = Type.Union([Type.Literal('Pending'), Type.Literal('Failed')]);
+
+export const TransactionResponse = Type.Object({
+  transactionStatus: Type.Object({
+    state: TransactionStatusState,
+    errors: Type.Array(
+      Type.Object({
+        code: Type.Literal('PaymentRejected'),
+        message: Type.String(),
+      }),
+    ),
+  }),
+});
+
+export type TransactionDraftSchemaDTO = Static<typeof TransactionDraft>;
+export type TransactionResponseSchemaDTO = Static<typeof TransactionResponse>;

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -19,7 +19,7 @@ const TransactionStateFailed = Type.Literal('Failed', {
   description: "Any error that occured for which the system can't recover automatically from.",
 });
 
-const TransactionStateComplete = Type.Literal('Complete', {
+const TransactionStateComplete = Type.Literal('Completed', {
   description: 'If there is a successful authorization/capture on the payment-transaction.',
 });
 

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -41,5 +41,5 @@ export const TransactionResponse = Type.Object({
   }),
 });
 
-export type TransactionDraftSchemaDTO = Static<typeof TransactionDraft>;
-export type TransactionResponseSchemaDTO = Static<typeof TransactionResponse>;
+export type TransactionDraftDTO = Static<typeof TransactionDraft>;
+export type TransactionResponseDTO = Static<typeof TransactionResponse>;

--- a/processor/src/routes/operation.route.ts
+++ b/processor/src/routes/operation.route.ts
@@ -130,28 +130,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
     },
     async (request, reply) => {
       const result = await opts.paymentService.handleTransaction(request.body);
-
-      // TODO: SCC-2580: find a nicer solution to the isSuccess flows
-      if (result.isSuccess) {
-        return reply.status(201).send({
-          transactionStatus: {
-            errors: [],
-            state: 'Pending',
-          },
-        });
-      } else {
-        return reply.status(201).send({
-          transactionStatus: {
-            errors: [
-              {
-                code: 'PaymentRejected',
-                message: `Payment '${result.payment.id}' has been rejected.`,
-              },
-            ],
-            state: 'Failed',
-          },
-        });
-      }
+      return reply.status(201).send(result);
     },
   );
 };

--- a/processor/src/routes/operation.route.ts
+++ b/processor/src/routes/operation.route.ts
@@ -124,7 +124,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
       schema: {
         body: TransactionDraft,
         response: {
-          200: TransactionResponse,
+          201: TransactionResponse,
         },
       },
     },

--- a/processor/src/routes/operation.route.ts
+++ b/processor/src/routes/operation.route.ts
@@ -18,9 +18,9 @@ import { StatusResponseSchema, StatusResponseSchemaDTO } from '../dtos/operation
 import { AbstractPaymentService } from '../services/abstract-payment.service';
 import {
   TransactionDraft,
-  TransactionDraftSchemaDTO,
+  TransactionDraftDTO,
   TransactionResponse,
-  TransactionResponseSchemaDTO,
+  TransactionResponseDTO,
 } from '../dtos/operations/transaction.dto';
 
 type OperationRouteOptions = {
@@ -114,7 +114,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
   );
 
   // Create transaction
-  fastify.post<{ Body: TransactionDraftSchemaDTO; Reply: TransactionResponseSchemaDTO }>(
+  fastify.post<{ Body: TransactionDraftDTO; Reply: TransactionResponseDTO }>(
     '/transactions',
     {
       preHandler: [

--- a/processor/src/routes/operation.route.ts
+++ b/processor/src/routes/operation.route.ts
@@ -16,6 +16,12 @@ import {
 } from '../dtos/operations/payment-intents.dto';
 import { StatusResponseSchema, StatusResponseSchemaDTO } from '../dtos/operations/status.dto';
 import { AbstractPaymentService } from '../services/abstract-payment.service';
+import {
+  TransactionDraft,
+  TransactionDraftSchemaDTO,
+  TransactionResponse,
+  TransactionResponseSchemaDTO,
+} from '../dtos/operations/transaction.dto';
 
 type OperationRouteOptions = {
   sessionHeaderAuthHook: SessionHeaderAuthenticationHook;
@@ -36,7 +42,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
         },
       },
     },
-    async (request, reply) => {
+    async (_, reply) => {
       const config = await opts.paymentService.config();
       reply.code(200).send(config);
     },
@@ -52,7 +58,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
         },
       },
     },
-    async (request, reply) => {
+    async (_, reply) => {
       const status = await opts.paymentService.status();
       reply.code(200).send(status);
     },
@@ -68,7 +74,7 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
         },
       },
     },
-    async (request, reply) => {
+    async (_, reply) => {
       const result = await opts.paymentService.getSupportedPaymentComponents();
       reply.code(200).send(result);
     },
@@ -104,6 +110,48 @@ export const operationsRoute = async (fastify: FastifyInstance, opts: FastifyPlu
       });
 
       return reply.status(200).send(resp);
+    },
+  );
+
+  // Create transaction
+  fastify.post<{ Body: TransactionDraftSchemaDTO; Reply: TransactionResponseSchemaDTO }>(
+    '/transactions',
+    {
+      preHandler: [
+        opts.oauth2AuthHook.authenticate(),
+        opts.authorizationHook.authorize('manage_project', 'manage_checkout_transactions'),
+      ],
+      schema: {
+        body: TransactionDraft,
+        response: {
+          200: TransactionResponse,
+        },
+      },
+    },
+    async (request, reply) => {
+      const result = await opts.paymentService.handleTransaction(request.body);
+
+      // TODO: SCC-2580: find a nicer solution to the isSuccess flows
+      if (result.isSuccess) {
+        return reply.status(201).send({
+          transactionStatus: {
+            errors: [],
+            state: 'Pending',
+          },
+        });
+      } else {
+        return reply.status(201).send({
+          transactionStatus: {
+            errors: [
+              {
+                code: 'PaymentRejected',
+                message: `Payment '${result.payment.id}' has been rejected.`,
+              },
+            ],
+            state: 'Failed',
+          },
+        });
+      }
     },
   );
 };

--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -21,7 +21,7 @@ import {
 } from '../dtos/operations/payment-intents.dto';
 
 import { SupportedPaymentComponentsSchemaDTO } from '../dtos/operations/payment-componets.dto';
-import { TransactionDraftSchemaDTO, TransactionResponseSchemaDTO } from '../dtos/operations/transaction.dto';
+import { TransactionDraftDTO, TransactionResponseDTO } from '../dtos/operations/transaction.dto';
 
 export abstract class AbstractPaymentService {
   protected ctCartService: CommercetoolsCartService;
@@ -104,7 +104,7 @@ export abstract class AbstractPaymentService {
    * @param transactionDraft the incoming request payload
    * @returns Promise with the created Payment and whether or not it was a success or not
    */
-  abstract handleTransaction(transactionDraft: TransactionDraftSchemaDTO): Promise<TransactionResponseSchemaDTO>;
+  abstract handleTransaction(transactionDraft: TransactionDraftDTO): Promise<TransactionResponseDTO>;
 
   /**
    * Modify payment

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -26,7 +26,7 @@ import { PaymentMethodType, PaymentOutcome, PaymentResponseSchemaDTO } from '../
 import { getCartIdFromContext, getPaymentInterfaceFromContext } from '../libs/fastify/context/context';
 import { randomUUID } from 'crypto';
 import { launchpadPurchaseOrderCustomType } from '../custom-types/custom-types';
-import { TransactionDraftSchemaDTO, TransactionResponseSchemaDTO } from '../dtos/operations/transaction.dto';
+import { TransactionDraftDTO, TransactionResponseDTO } from '../dtos/operations/transaction.dto';
 
 export class MockPaymentService extends AbstractPaymentService {
   constructor(opts: MockPaymentServiceOptions) {
@@ -244,7 +244,7 @@ export class MockPaymentService extends AbstractPaymentService {
     };
   }
 
-  public async handleTransaction(transactionDraft: TransactionDraftSchemaDTO): Promise<TransactionResponseSchemaDTO> {
+  public async handleTransaction(transactionDraft: TransactionDraftDTO): Promise<TransactionResponseDTO> {
     const TRANSACTION_AUTHORIZATION_TYPE: TransactionType = 'Authorization';
     const TRANSACTION_STATE_SUCCESS: TransactionState = 'Success';
     const TRANSACTION_STATE_FAILURE: TransactionState = 'Failure';

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -2,6 +2,8 @@ import {
   statusHandler,
   healthCheckCommercetoolsPermissions,
   ErrorRequiredField,
+  TransactionType,
+  TransactionState,
 } from '@commercetools/connect-payments-sdk';
 import {
   CancelPaymentRequest,
@@ -24,6 +26,7 @@ import { PaymentMethodType, PaymentOutcome, PaymentResponseSchemaDTO } from '../
 import { getCartIdFromContext, getPaymentInterfaceFromContext } from '../libs/fastify/context/context';
 import { randomUUID } from 'crypto';
 import { launchpadPurchaseOrderCustomType } from '../custom-types/custom-types';
+import { TransactionDraftSchemaDTO, TransactionResponseSchemaDTO } from '../dtos/operations/transaction.dto';
 
 export class MockPaymentService extends AbstractPaymentService {
   constructor(opts: MockPaymentServiceOptions) {
@@ -239,6 +242,70 @@ export class MockPaymentService extends AbstractPaymentService {
     return {
       paymentReference: updatedPayment.id,
     };
+  }
+
+  public async handleTransaction(transactionDraft: TransactionDraftSchemaDTO): Promise<TransactionResponseSchemaDTO> {
+    const TRANSACTION_AUTHORIZATION_TYPE: TransactionType = 'Authorization';
+    const TRANSACTION_STATE_SUCCESS: TransactionState = 'Success';
+    const TRANSACTION_STATE_FAILURE: TransactionState = 'Failure';
+
+    const maxCentAmountIfSuccess = 10000;
+
+    const ctCart = await this.ctCartService.getCart({ id: transactionDraft.cartId });
+
+    let amountPlanned = transactionDraft.amount;
+    if (!amountPlanned) {
+      amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
+    }
+
+    const isBelowSuccessStateThreshold = amountPlanned.centAmount < maxCentAmountIfSuccess;
+
+    const transactionState: TransactionState = isBelowSuccessStateThreshold
+      ? TRANSACTION_STATE_SUCCESS
+      : TRANSACTION_STATE_FAILURE;
+
+    const newlyCreatedPayment = await this.ctPaymentService.createPayment({
+      amountPlanned,
+      paymentMethodInfo: {
+        paymentInterface: transactionDraft.paymentInterface,
+      },
+      transactions: [
+        {
+          amount: amountPlanned,
+          type: TRANSACTION_AUTHORIZATION_TYPE,
+          state: transactionState,
+        },
+      ],
+    });
+
+    await this.ctCartService.addPayment({
+      resource: {
+        id: ctCart.id,
+        version: ctCart.version,
+      },
+      paymentId: newlyCreatedPayment.id,
+    });
+
+    if (isBelowSuccessStateThreshold) {
+      return {
+        transactionStatus: {
+          errors: [],
+          state: 'Pending',
+        },
+      };
+    } else {
+      return {
+        transactionStatus: {
+          errors: [
+            {
+              code: 'PaymentRejected',
+              message: `Payment '${newlyCreatedPayment.id}' has been rejected.`,
+            },
+          ],
+          state: 'Failed',
+        },
+      };
+    }
   }
 
   private convertPaymentResultCode(resultCode: PaymentOutcome): string {

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -244,4 +244,6 @@ describe('mock-payment.service', () => {
 
     await expect(resultPromise).rejects.toThrow('A value is required for field poNumber.');
   });
+
+  // TODO: SCC-2580: write tests for the handleTransactions payment-service function
 });

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -14,7 +14,7 @@ import * as StatusHandler from '@commercetools/connect-payments-sdk/dist/api/han
 
 import { HealthCheckResult } from '@commercetools/connect-payments-sdk';
 import { PaymentMethodType, PaymentOutcome } from '../src/dtos/mock-payment.dto';
-import { TransactionDraftSchemaDTO } from '../src/dtos/operations/transaction.dto';
+import { TransactionDraftDTO } from '../src/dtos/operations/transaction.dto';
 
 interface FlexibleConfig {
   [key: string]: string; // Adjust the type according to your config values
@@ -248,7 +248,7 @@ describe('mock-payment.service', () => {
 
   describe('handleTransaction', () => {
     test('should create the payment in CoCo and return it with a success state', async () => {
-      const createPaymentOpts: TransactionDraftSchemaDTO = {
+      const createPaymentOpts: TransactionDraftDTO = {
         cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
         paymentInterface: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
         amount: {
@@ -273,7 +273,7 @@ describe('mock-payment.service', () => {
     });
 
     test('should create the payment in CoCo and return it with a failed state', async () => {
-      const createPaymentOpts: TransactionDraftSchemaDTO = {
+      const createPaymentOpts: TransactionDraftDTO = {
         cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
         paymentInterface: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
         amount: {

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -14,6 +14,7 @@ import * as StatusHandler from '@commercetools/connect-payments-sdk/dist/api/han
 
 import { HealthCheckResult } from '@commercetools/connect-payments-sdk';
 import { PaymentMethodType, PaymentOutcome } from '../src/dtos/mock-payment.dto';
+import { TransactionDraftSchemaDTO } from '../src/dtos/operations/transaction.dto';
 
 interface FlexibleConfig {
   [key: string]: string; // Adjust the type according to your config values
@@ -245,5 +246,61 @@ describe('mock-payment.service', () => {
     await expect(resultPromise).rejects.toThrow('A value is required for field poNumber.');
   });
 
-  // TODO: SCC-2580: write tests for the handleTransactions payment-service function
+  describe('handleTransaction', () => {
+    test('should create the payment in CoCo and return it with a success state', async () => {
+      const createPaymentOpts: TransactionDraftSchemaDTO = {
+        cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
+        paymentInterface: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
+        amount: {
+          centAmount: 1000,
+          currencyCode: 'EUR',
+        },
+      };
+
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'createPayment')
+        .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
+      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+
+      const resultPromise = mockPaymentService.handleTransaction(createPaymentOpts);
+      expect(resultPromise).resolves.toStrictEqual({
+        transactionStatus: {
+          errors: [],
+          state: 'Pending',
+        },
+      });
+    });
+
+    test('should create the payment in CoCo and return it with a failed state', async () => {
+      const createPaymentOpts: TransactionDraftSchemaDTO = {
+        cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
+        paymentInterface: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
+        amount: {
+          centAmount: 10000,
+          currencyCode: 'EUR',
+        },
+      };
+
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'createPayment')
+        .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
+      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+
+      const resultPromise = mockPaymentService.handleTransaction(createPaymentOpts);
+
+      expect(resultPromise).resolves.toStrictEqual({
+        transactionStatus: {
+          errors: [
+            {
+              code: 'PaymentRejected',
+              message: `Payment '${mockGetPaymentResult.id}' has been rejected.`,
+            },
+          ],
+          state: 'Failed',
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2580

This PR adds a (example) transaction API handler. Based on the given payload the API handler will:

1. determine the amount for the transaction (either the given amount or the full amount from the given cartId)
2. create a payment in CoCo
3. assign the payment to the given cartId via the cart update action `AddPayment`
4. returns the transaction result