### PR TITLE
chore(processor): update handleTransactions logic

### DIFF
--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -260,7 +260,7 @@ export class MockPaymentService extends AbstractPaymentService {
 
     const isBelowSuccessStateThreshold = amountPlanned.centAmount < maxCentAmountIfSuccess;
 
-    const newCtPayment = await this.ctPaymentService.createPayment({
+    const newlyCreatedPayment = await this.ctPaymentService.createPayment({
       amountPlanned,
       paymentMethodInfo: {
         paymentInterface: transactionDraft.paymentInterface,
@@ -272,7 +272,7 @@ export class MockPaymentService extends AbstractPaymentService {
         id: ctCart.id,
         version: ctCart.version,
       },
-      paymentId: newCtPayment.id,
+      paymentId: newlyCreatedPayment.id,
     });
 
     const transactionState: TransactionState = isBelowSuccessStateThreshold
@@ -280,7 +280,7 @@ export class MockPaymentService extends AbstractPaymentService {
       : TRANSACTION_STATE_FAILURE;
 
     await this.ctPaymentService.updatePayment({
-      id: newCtPayment.id,
+      id: newlyCreatedPayment.id,
       transaction: {
         amount: amountPlanned,
         type: TRANSACTION_AUTHORIZATION_TYPE,
@@ -301,7 +301,7 @@ export class MockPaymentService extends AbstractPaymentService {
           errors: [
             {
               code: 'PaymentRejected',
-              message: `Payment '${newCtPayment.id}' has been rejected.`,
+              message: `Payment '${newlyCreatedPayment.id}' has been rejected.`,
             },
           ],
           state: 'Failed',

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -279,12 +279,16 @@ export class MockPaymentService extends AbstractPaymentService {
       ? TRANSACTION_STATE_SUCCESS
       : TRANSACTION_STATE_FAILURE;
 
+    const pspReference = randomUUID().toString();
+
     await this.ctPaymentService.updatePayment({
       id: newlyCreatedPayment.id,
+      pspReference: pspReference,
       transaction: {
         amount: amountPlanned,
         type: TRANSACTION_AUTHORIZATION_TYPE,
         state: transactionState,
+        interactionId: pspReference,
       },
     });
 

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -265,16 +265,6 @@ export class MockPaymentService extends AbstractPaymentService {
       paymentMethodInfo: {
         paymentInterface: transactionDraft.paymentInterface,
       },
-      ...(ctCart.customerId && {
-        customer: {
-          typeId: 'customer',
-          id: ctCart.customerId,
-        },
-      }),
-      ...(!ctCart.customerId &&
-        ctCart.anonymousId && {
-          anonymousId: ctCart.anonymousId,
-        }),
     });
 
     await this.ctCartService.addPayment({

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -262,6 +262,9 @@ describe('mock-payment.service', () => {
         .spyOn(DefaultPaymentService.prototype, 'createPayment')
         .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
       jest.spyOn(DefaultCartService.prototype, 'addPayment').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
 
       const resultPromise = mockPaymentService.handleTransaction(createPaymentOpts);
       expect(resultPromise).resolves.toStrictEqual({
@@ -287,6 +290,9 @@ describe('mock-payment.service', () => {
         .spyOn(DefaultPaymentService.prototype, 'createPayment')
         .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
       jest.spyOn(DefaultCartService.prototype, 'addPayment').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
 
       const resultPromise = mockPaymentService.handleTransaction(createPaymentOpts);
 


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2580

While testing the transactions API and the corresponding mock implementation in this connector template we found an issue. Checkout requires a specific set of CoCo interactions for the underlying subscriptions/messages to be processed correctly.

Essentially this means that we need to add the transaction to the payment via the `updatePayment` interaction instead of directly via the `createPayment`.