### PR TITLE
feat(spa): Cleanup connector styles on closing SPA

### DIFF
--- a/enabler/vite.config.ts
+++ b/enabler/vite.config.ts
@@ -1,20 +1,42 @@
-import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { resolve } from "path";
+import { defineConfig } from "vite";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
 export default defineConfig({
   plugins: [
-    cssInjectedByJsPlugin(),
+    cssInjectedByJsPlugin({
+      injectCodeFunction: function injectCodeCustomRunTimeFunction(
+        cssCode: string,
+        options
+      ) {
+        try {
+          if (typeof document != "undefined") {
+            var elementStyle = document.createElement("style");
+            elementStyle.setAttribute("data-ctc-connector-styles", "");
+            for (const attribute in options.attributes) {
+              elementStyle.setAttribute(
+                attribute,
+                options.attributes[attribute]
+              );
+            }
+            elementStyle.appendChild(document.createTextNode(cssCode));
+            document.head.appendChild(elementStyle);
+          }
+        } catch (e) {
+          console.error("vite-plugin-css-injected-by-js", e);
+        }
+      },
+    }),
   ],
   build: {
-    outDir: resolve(__dirname, 'public'),
+    outDir: resolve(__dirname, "public"),
     lib: {
       // Could also be a dictionary or array of multiple entry points
-      entry: resolve(__dirname, 'src/main.ts'),
-      name: 'Connector',
-      formats: ['es','umd'],
+      entry: resolve(__dirname, "src/main.ts"),
+      name: "Connector",
+      formats: ["es", "umd"],
       // the proper extensions will be added
       fileName: (format) => `connector-enabler.${format}.js`,
     },
   },
-})
+});

--- a/enabler/vite.config.ts
+++ b/enabler/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
         try {
           if (typeof document != "undefined") {
             var elementStyle = document.createElement("style");
+            // checkout will look for this attribute to remove the style tag
+            // when the checkout is closed for cleanup purposes
             elementStyle.setAttribute("data-ctc-connector-styles", "");
             for (const attribute in options.attributes) {
               elementStyle.setAttribute(

--- a/enabler/vite.config.ts
+++ b/enabler/vite.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
         try {
           if (typeof document != "undefined") {
             var elementStyle = document.createElement("style");
-            // checkout will look for this attribute to remove the style tag
-            // when the checkout is closed for cleanup purposes
+            // this attribute will allow the client application using this connector to
+            // identify the style tag and remove it if needed for cleanup purposes
             elementStyle.setAttribute("data-ctc-connector-styles", "");
             for (const attribute in options.attributes) {
               elementStyle.setAttribute(


### PR DESCRIPTION
This connector injects a <style> tag into the document head with the CSS code provided.

This PR is to include an attribute to the adyen style tag for later cleanup through the SPA after closing:

https://commercetools.atlassian.net/browse/SCC-2721

The attribute will look like this: <style data-ctc-connector-styles>....</style>