### PR TITLE
feat(payments): Add paymentReference to onSuccess and onError callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .env
 .connect
+.vscode

--- a/enabler/src/components/base.ts
+++ b/enabler/src/components/base.ts
@@ -18,7 +18,7 @@ export abstract class BaseComponent implements PaymentComponent {
   protected sessionId: BaseOptions['sessionId'];
   protected environment: BaseOptions['environment'];
   protected onComplete: (result: PaymentResult) => void;
-  protected onError: (error: any, payload?: { paymentReference?: string }) => void;
+  protected onError: (error: any, context?: { paymentReference?: string }) => void;
 
   constructor(paymentMethod: PaymentMethod, baseOptions: BaseOptions, _componentOptions: ComponentOptions) {
     this.paymentMethod = paymentMethod;

--- a/enabler/src/components/base.ts
+++ b/enabler/src/components/base.ts
@@ -18,7 +18,7 @@ export abstract class BaseComponent implements PaymentComponent {
   protected sessionId: BaseOptions['sessionId'];
   protected environment: BaseOptions['environment'];
   protected onComplete: (result: PaymentResult) => void;
-  protected onError: (error?: any) => void;
+  protected onError: (error: any, payload?: { paymentReference?: string }) => void;
 
   constructor(paymentMethod: PaymentMethod, baseOptions: BaseOptions, _componentOptions: ComponentOptions) {
     this.paymentMethod = paymentMethod;

--- a/enabler/src/components/payment-methods/card/card.ts
+++ b/enabler/src/components/payment-methods/card/card.ts
@@ -79,12 +79,9 @@ export class Card extends BaseComponent {
         body: JSON.stringify(request),
       });
       const data = await response.json();
+      const isSuccess = resultCode === PaymentOutcome.AUTHORIZED;
 
-      if (resultCode === PaymentOutcome.AUTHORIZED) {
-        this.onComplete && this.onComplete({ isSuccess: true, paymentReference: data.paymentReference });
-      } else {
-        this.onComplete && this.onComplete({ isSuccess: false });
-      }
+      this.onComplete && this.onComplete({ isSuccess, paymentReference: data.paymentReference });
     } catch(e) {
       this.onError('Some error occurred. Please try again.');
     }

--- a/enabler/src/payment-enabler/payment-enabler-mock.ts
+++ b/enabler/src/payment-enabler/payment-enabler-mock.ts
@@ -25,7 +25,7 @@ export type BaseOptions = {
   environment: string;
   locale?: string;
   onComplete: (result: PaymentResult) => void;
-  onError: (error: any, payload?: { paymentReference?: string }) => void;
+  onError: (error: any, context?: { paymentReference?: string }) => void;
 };
 
 export class MockPaymentEnabler implements PaymentEnabler {

--- a/enabler/src/payment-enabler/payment-enabler-mock.ts
+++ b/enabler/src/payment-enabler/payment-enabler-mock.ts
@@ -25,7 +25,7 @@ export type BaseOptions = {
   environment: string;
   locale?: string;
   onComplete: (result: PaymentResult) => void;
-  onError: (error?: any) => void;
+  onError: (error: any, payload?: { paymentReference?: string }) => void;
 };
 
 export class MockPaymentEnabler implements PaymentEnabler {

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -149,7 +149,7 @@ export type EnablerOptions = {
    */
   onError?: (
     error: any,
-    payload?: { paymentReference?: string }
+    context?: { paymentReference?: string }
   ) => void;
 };
 

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -145,8 +145,12 @@ export type EnablerOptions = {
   /**
    * A callback function that is called when an error occurs during the payment process.
    * @param error - The error that occurred.
+   * @param paymentReference - The payment reference.
    */
-  onError?: (error: any) => void;
+  onError?: (
+    error: any,
+    payload?: { paymentReference?: string }
+  ) => void;
 };
 
 /**
@@ -201,6 +205,11 @@ export type PaymentResult =
        * Indicates whether the payment was unsuccessful.
        */
       isSuccess: false;
+
+      /**
+       * The payment reference.
+       */
+      paymentReference?: string;
     };
 
 /**


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3041

Some customer is requesting that we forward the payment reference in failure cases. ATM we're just sending this on success cases, but there's no reason for not sending it on failure cases if available, so we're adding this as a reference