### PR TITLE
chore(rv): add back interaction id to the transaction objects

### DIFF
--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -13,7 +13,6 @@ import {
   ReversePaymentRequest,
   StatusResponse,
 } from './types/operation.type';
-import { PaymentIntentResponseSchemaDTO } from '../dtos/operations/payment-intents.dto';
 
 import { SupportedPaymentComponentsSchemaDTO } from '../dtos/operations/payment-componets.dto';
 import { TransactionDraftDTO, TransactionResponseDTO } from '../dtos/operations/transaction.dto';
@@ -121,7 +120,7 @@ export abstract class AbstractPaymentService {
    * @param opts - input for payment modification including payment ID, action and payment amount
    * @returns Promise with outcome of payment modification after invocation to PSPs
    */
-  public async modifyPayment(opts: ModifyPayment): Promise<PaymentIntentResponseSchemaDTO> {
+  public async modifyPayment(opts: ModifyPayment): Promise<PaymentProviderModificationResponse> {
     const ctPayment = await this.ctPaymentService.getPayment({
       id: opts.paymentId,
     });

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -151,6 +151,7 @@ export class MockPaymentService extends AbstractPaymentService {
       transaction: {
         type: 'Charge',
         amount: request.amount,
+        interactionId: request.payment.interfaceId,
         state: 'Success',
       },
     });
@@ -172,6 +173,7 @@ export class MockPaymentService extends AbstractPaymentService {
       transaction: {
         type: 'CancelAuthorization',
         amount: request.payment.amountPlanned,
+        interactionId: request.payment.interfaceId,
         state: 'Success',
       },
     });
@@ -193,6 +195,7 @@ export class MockPaymentService extends AbstractPaymentService {
       transaction: {
         type: 'Refund',
         amount: request.amount,
+        interactionId: request.payment.interfaceId,
         state: 'Success',
       },
     });


### PR DESCRIPTION
Related Ticket: https://commercetools.atlassian.net/browse/SCC-3071

In refactoring the modify payment services, due to an oversight we removed the interaction id from transaction created from a modification request.

