### PR TITLE
fix(payments): Added aria labels in sample card for accessibility

### DIFF
--- a/enabler/src/components/payment-methods/card/card.ts
+++ b/enabler/src/components/payment-methods/card/card.ts
@@ -97,8 +97,8 @@ export class Card extends BaseComponent {
           <label class="${inputFieldStyles.inputLabel}" for="creditCardForm-cardNumber">
             Card number <span aria-hidden="true"> *</span>
           </label>
-          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-cardNumber" name="cardNumber" value="">
-          <span class="${styles.hidden} ${inputFieldStyles.errorField}" tabindex="0">Invalid card number</span>
+          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-cardNumber" name="cardNumber" value="" aria-describedby="cardNumberInput-ally">
+          <span class="${styles.hidden} ${inputFieldStyles.errorField}" id="cardNumberInput-ally" role="alert" aria-live="assertive" tabindex="0">Invalid card number</span>
           <div class="${styles.cardRow}" tabindex="-1">
             <img id="creditCardForm-visa" src="data:image/svg+xml,%3csvg width='70' height='48' viewBox='0 0 70 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3crect x='0.5' y='0.5' width='69' height='47' rx='5.5' fill='white' stroke='%23D9D9D9' /%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.2505 32.5165H17.0099L13.8299 20.3847C13.679 19.8267 13.3585 19.3333 12.8871 19.1008C11.7106 18.5165 10.4142 18.0514 9 17.8169V17.3498H15.8313C16.7742 17.3498 17.4813 18.0514 17.5991 18.8663L19.2491 27.6173L23.4877 17.3498H27.6104L21.2505 32.5165ZM29.9675 32.5165H25.9626L29.2604 17.3498H33.2653L29.9675 32.5165ZM38.4467 21.5514C38.5646 20.7346 39.2717 20.2675 40.0967 20.2675C41.3931 20.1502 42.8052 20.3848 43.9838 20.9671L44.6909 17.7016C43.5123 17.2345 42.216 17 41.0395 17C37.1524 17 34.3239 19.1008 34.3239 22.0165C34.3239 24.2346 36.3274 25.3992 37.7417 26.1008C39.2717 26.8004 39.861 27.2675 39.7431 27.9671C39.7431 29.0165 38.5646 29.4836 37.3881 29.4836C35.9739 29.4836 34.5596 29.1338 33.2653 28.5494L32.5582 31.8169C33.9724 32.3992 35.5025 32.6338 36.9167 32.6338C41.2752 32.749 43.9838 30.6502 43.9838 27.5C43.9838 23.5329 38.4467 23.3004 38.4467 21.5514ZM58 32.5165L54.82 17.3498H51.4044C50.6972 17.3498 49.9901 17.8169 49.7544 18.5165L43.8659 32.5165H47.9887L48.8116 30.3004H53.8772L54.3486 32.5165H58ZM51.9936 21.4342L53.1701 27.1502H49.8723L51.9936 21.4342Z' fill='%23172B85' /%3e %3c/svg%3e" class="${styles.cardIcon}" width="23" height="16" alt="">
             <img id="creditCardForm-amex" src="data:image/svg+xml,%3csvg width='70' height='48' viewBox='0 0 70 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3crect x='0.5' y='0.5' width='69' height='47' rx='5.5' fill='%231F72CD' stroke='%23D9D9D9' /%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.5493 17L6 31.4935H13.8405L14.8125 29.1826H17.0342L18.0062 31.4935H26.6364V29.7298L27.4054 31.4935H31.8696L32.6386 29.6925V31.4935H50.587L52.7695 29.2426L54.813 31.4935L64.0317 31.5121L57.4617 24.2872L64.0317 17H54.956L52.8315 19.2093L50.8523 17H31.3268L29.6501 20.7409L27.9341 17H20.11V18.7037L19.2396 17H12.5493ZM39.3516 19.0581H49.6584L52.8108 22.4633L56.0648 19.0581H59.2172L54.4275 24.2852L59.2172 29.452H55.9218L52.7695 26.0073L49.4989 29.452H39.3516V19.0581ZM41.8968 23.1099V21.2114V21.2096H48.328L51.1342 24.2458L48.2036 27.2986H41.8968V25.226H47.5197V23.1099H41.8968ZM14.0664 19.0581H17.8883L22.2324 28.8862V19.0581H26.4191L29.7745 26.1048L32.8668 19.0581H37.0326V29.4581H34.4978L34.4771 21.3087L30.7817 29.4581H28.5142L24.7981 21.3087V29.4581H19.5836L18.595 27.1266H13.254L12.2675 29.4561H9.47358L14.0664 19.0581ZM14.166 24.9712L15.9256 20.8177L17.6832 24.9712H14.166Z' fill='white' /%3e %3c/svg%3e" class="${styles.cardIcon}" width="23" height="16" alt="">
@@ -112,23 +112,23 @@ export class Card extends BaseComponent {
               Expiry date 
               <span aria-hidden="true"> *</span>
             </label>
-          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-expiryDate" name="expiryDate" inputmode="numeric" value="">
-          <span class="${styles.hidden} ${inputFieldStyles.errorField}" tabindex="0">Invalid expiry date</span>
+          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-expiryDate" name="expiryDate" inputmode="numeric" value="" aria-describedby="expiryDateInput-ally">
+          <span class="${styles.hidden} ${inputFieldStyles.errorField}" id="expiryDateInput-ally" role="alert" aria-live="assertive" tabindex="0">Invalid expiry date</span>
         </div>
         <div class="${inputFieldStyles.inputContainer}">
           <label class="${inputFieldStyles.inputLabel}" for="creditCardForm-cvv">
             CVC/CVV <span aria-hidden="true"> *</span>
           </label>
-          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-cvv" name="cvv" value="">
-          <span class="${styles.hidden} ${inputFieldStyles.errorField}" tabindex="0">Invalid CVV</span>
+          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-cvv" name="cvv" value="" aria-describedby="cvvInput-ally">
+          <span class="${styles.hidden} ${inputFieldStyles.errorField}" id="cvvInput-ally" role="alert" aria-live="assertive" tabindex="0">Invalid CVV</span>
         </div>
         </div>
         <div class="${inputFieldStyles.inputContainer}">
           <label class="${inputFieldStyles.inputLabel}" for="creditCardForm-holderNameLabel">
             Name on card <span aria-hidden="true"> *</span>
           </label>
-          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-holderNameLabel" name="cardHolderName" value="">
-          <span class="${styles.hidden} ${inputFieldStyles.errorField}" tabindex="0">This field is required</span>
+          <input class="${inputFieldStyles.inputField}" type="text" id="creditCardForm-holderNameLabel" name="cardHolderName" value="" aria-describedby="holderNameInput-ally">
+          <span class="${styles.hidden} ${inputFieldStyles.errorField}" id="holderNameInput-ally" role="alert" aria-live="assertive" tabindex="0">This field is required</span>
         </div>
         ${payButton}
       </form>


### PR DESCRIPTION
Related [ticket](https://commercetools.atlassian.net/browse/SCC-3020)

Small fix as part of an accessibility epic. Added aria label to enable e-readers to pick up error messages for Sample Credit Card.

<img width="1572" alt="Screenshot 2025-06-16 at 12 31 10" src="https://github.com/user-attachments/assets/4422f756-2c48-4a91-929f-4126c8827b05" />
