### PR TITLE
- updated styling for custom card payment method

### DIFF
--- a/enabler/src/components/payment-methods/card/card.ts
+++ b/enabler/src/components/payment-methods/card/card.ts
@@ -92,7 +92,9 @@ export class Card extends BaseComponent {
     return `
     <div class="${styles.wrapper}">
       <form class="${styles.paymentForm}">
-        <div class="${inputFieldStyles.inputContainer}"> * Required fields for payment by credit card </div>
+        <div class="${inputFieldStyles.inputContainer}"> 
+          <p class="${inputFieldStyles.helperText}">* Required fields for payment by credit card <p>
+        </div>
         <div class="${inputFieldStyles.inputContainer}">
           <label class="${inputFieldStyles.inputLabel}" for="creditCardForm-cardNumber">
             Card number <span aria-hidden="true"> *</span>

--- a/enabler/src/style/inputField.module.scss
+++ b/enabler/src/style/inputField.module.scss
@@ -50,9 +50,10 @@
 
   .helperText {
     color: variables.$color-text-helper;
-    font-size: 0.75rem;
-    line-height: 0.75rem;
-    padding: 0.25rem 0.75rem 0.25rem 1rem;
+    font-size: 0.8125rem;
+    line-height: 1.5rem;
+    padding: 0;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
JIRA: [SCC-3427](https://commercetools.atlassian.net/browse/SCC-3427)

The PR incorporates minor design changes to the helper text on the custom card payment method. The `helperText` class was not being used elsewhere in the codebase and hence was used and updated to achieve the desired result.

Ref:
<img width="592" height="425" alt="Screenshot 2025-07-15 at 16 09 28" src="https://github.com/user-attachments/assets/fe6e0f37-b862-4ceb-912a-28c5d7effaba" />


[SCC-3427]: https://commercetools.atlassian.net/browse/SCC-3427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ