### PR TITLE
fix(processor): Implement Shared Custom Type Pattern to prevent overwrites in connector

### DIFF
--- a/processor/.env.template
+++ b/processor/.env.template
@@ -12,3 +12,7 @@ CTP_JWT_ISSUER=https://mc-api.[region].commercetools.com
 # Merchant return URL for redirecting the user back to the merchant website after the payment is completed
 # Use it as a fallback if no merchantReturnUrl is provided in the session
 MERCHANT_RETURN_URL=[Merchant-website-return-url]
+
+# Key of the commercetools custom type used to store additional fields.
+# Can be shared with other connectors to avoid conflicts - all connectors pointing at the same key will contribute their fields to that type.
+TYPE_DEFINITION_KEY=payment-launchpad-purchase-order

--- a/processor/src/connectors/actions.ts
+++ b/processor/src/connectors/actions.ts
@@ -9,7 +9,7 @@ export async function createLaunchpadPurchaseOrderNumberCustomType(): Promise<vo
     .types()
     .get({
       queryArgs: {
-        where: `key="${launchpadPurchaseOrderCustomType.key}"`, // TODO: needs to be configured in connect.yaml
+        where: `key="${launchpadPurchaseOrderCustomType.key}"`,
       },
     })
     .execute();

--- a/processor/src/connectors/actions.ts
+++ b/processor/src/connectors/actions.ts
@@ -9,13 +9,51 @@ export async function createLaunchpadPurchaseOrderNumberCustomType(): Promise<vo
     .types()
     .get({
       queryArgs: {
-        where: `key="${launchpadPurchaseOrderCustomType.key}"`,
+        where: `key="${launchpadPurchaseOrderCustomType.key}"`, // TODO: needs to be configured in connect.yaml
       },
     })
     .execute();
 
+  const requiredFields = [
+    {
+      type: { name: 'String' as const },
+      name: launchpadPurchaseOrderCustomType.purchaseOrderNumber,
+      label: { en: 'Purchase Order Number' },
+      required: true,
+    },
+    {
+      type: { name: 'String' as const },
+      name: launchpadPurchaseOrderCustomType.invoiceMemo,
+      label: { en: 'Invoice Memo' },
+      required: false,
+    },
+  ];
+
   if (getRes.body.results.length) {
-    log.info('Launchpad purchase order number custom type already exists. Skipping creation.');
+    const existingType = getRes.body.results[0];
+    const existingFieldNames = existingType.fieldDefinitions.map((f) => f.name);
+    const missingFields = requiredFields.filter((field) => !existingFieldNames.includes(field.name));
+
+    if (!missingFields.length) {
+      log.info('Launchpad purchase order number custom type already exists with all required fields. Skipping.');
+      return;
+    }
+
+    await apiClient
+      .types()
+      .withKey({ key: launchpadPurchaseOrderCustomType.key })
+      .post({
+        body: {
+          version: existingType.version,
+          actions: missingFields.map((field) => ({
+            action: 'addFieldDefinition' as const,
+            fieldDefinition: field,
+          })),
+        },
+      })
+      .execute();
+
+    log.info('Launchpad purchase order number custom type updated with missing fields.');
     return;
   }
 
@@ -26,28 +64,7 @@ export async function createLaunchpadPurchaseOrderNumberCustomType(): Promise<vo
         key: launchpadPurchaseOrderCustomType.key,
         name: { en: 'Additional fields to store purchase order information' },
         resourceTypeIds: ['payment'],
-        fieldDefinitions: [
-          {
-            type: {
-              name: 'String',
-            },
-            name: launchpadPurchaseOrderCustomType.purchaseOrderNumber,
-            label: {
-              en: 'Purchase Order Number',
-            },
-            required: true,
-          },
-          {
-            type: {
-              name: 'String',
-            },
-            name: launchpadPurchaseOrderCustomType.invoiceMemo,
-            label: {
-              en: 'Invoce Memo',
-            },
-            required: false,
-          },
-        ],
+        fieldDefinitions: requiredFields,
       },
     })
     .execute();

--- a/processor/src/custom-types/custom-types.ts
+++ b/processor/src/custom-types/custom-types.ts
@@ -1,5 +1,5 @@
 export const launchpadPurchaseOrderCustomType = {
-  key: 'payment-launchpad-purchase-order',
+  key: process.env.TYPE_DEFINITION_KEY || 'payment-launchpad-purchase-order',
   purchaseOrderNumber: 'launchpadPurchaseOrderNumber',
   invoiceMemo: 'launchpadPurchaseOrderInvoiceMemo',
 };


### PR DESCRIPTION
**Background:**
In Composable Commerce, a resource can reference only one Custom Type at a time. When multiple connectors or services independently create and assign their own Custom Types, they overwrite each other, causing loss of existing custom fields and data. See ticket [here](https://commercetools.atlassian.net/browse/SCC-3787) and slack [here](https://commercetools.slack.com/archives/C03E47K2C7N/p1768998227284679?thread_ts=1768997642.046139&cid=C03E47K2C7N)  

**Solution:** 
- Modified the connector to accept a configurable Custom Type key 