### PR TITLE
feat(recurring-orders): add support for processing server to server payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ deployAs:
           description: commercetools project key
           required: true
         - key: CTP_CLIENT_ID
-          description: commercetools client ID with manage_payments, manage_orders, view_sessions, view_api_clients, manage_checkout_payment_intents & introspect_oauth_tokens scopes
+          description: commercetools client ID with manage_payments, manage_orders, view_sessions, view_api_clients & introspect_oauth_tokens scopes
           required: true
         - key: CTP_AUTH_URL
           description: commercetools Auth URL
@@ -129,7 +129,7 @@ deployAs:
 Here you can see the details about various variables in configuration
 
 - `CTP_PROJECT_KEY`: The key of commercetools composable commerce project.
-- `CTP_CLIENT_ID`: The client ID of your commercetools composable commerce user account. It is used in commercetools client to communicate with commercetools composable commerce via SDK. Expected scopes are: `manage_payments` `manage_orders` `view_sessions` `view_api_clients` `manage_checkout_payment_intents` `introspect_oauth_tokens` `manage_types` `view_types`.
+- `CTP_CLIENT_ID`: The client ID of your commercetools composable commerce user account. It is used in commercetools client to communicate with commercetools composable commerce via SDK. Expected scopes are: `manage_payments` `manage_orders` `view_sessions` `view_api_clients` `introspect_oauth_tokens` `manage_types` `view_types`.
 - `CTP_CLIENT_SECRET`: The client secret of commercetools composable commerce user account. It is used in commercetools client to communicate with commercetools composable commerce via SDK.
 - `CTP_AUTH_URL`: The URL for authentication in commercetools platform. It is used to generate OAuth 2.0 token which is required in every API call to commercetools composable commerce. The default value is `https://auth.europe-west1.gcp.commercetools.com`. For details, please refer to documentation [here](https://docs.commercetools.com/tutorials/api-tutorial#authentication).
 - `CTP_API_URL`: The URL for commercetools composable commerce API. Default value is `https://api.europe-west1.gcp.commercetools.com`.
@@ -164,6 +164,21 @@ Currently supported payment-methods for storing:
 When a payment method is tokenized for the first time the psp template connector will create a new CT payment-method. The payment-method is attached to the `cart.customerId` as well as the `paymentInterface` and `interfaceAccount` are set based on the previously configured env values.
 
 The next time the same customer goes through Checkout (either using drop-ins or web-components) they will see the stored payment method as a option to pay with.
+
+### Server-to-server recurring payments
+
+Once a payment method has been tokenized (see [stored payment methods](#stored-payment-methods) above), a backend system - for example the system responsible for commercetools recurring orders - can charge that stored payment method directly, server-to-server. This is a different flow from the client-to-server flows described above: there is no shopper session and no redirect involved, since the shopper is not present when the charge happens.
+
+#### Endpoint
+
+`POST /operations/transactions`
+
+For the full request/response contract, see [Create transaction](./processor/README.md#create-transaction) in the processor documentation.
+
+#### Requirements
+
+- The stored payment methods feature must be enabled (see [Setting up stored payment methods](#setting-up-stored-payment-methods)) - a token to charge must already exist.
+- The caller must present an OAuth2 token with the `manage_project` and `manage_checkout_transactions` scopes.
 
 ## Development
 

--- a/connect.yaml
+++ b/connect.yaml
@@ -13,7 +13,7 @@ deployAs:
           description: commercetools project key
           required: true
         - key: CTP_CLIENT_ID
-          description: commercetools client ID with manage_payments, manage_orders, view_sessions, view_api_clients, manage_checkout_payment_intents, introspect_oauth_tokens, manage_types and view_types scopes
+          description: commercetools client ID with manage_payments, manage_orders, view_sessions, view_api_clients, introspect_oauth_tokens, manage_types and view_types scopes
           required: true
         - key: CTP_AUTH_URL
           description: commercetools Auth URL

--- a/processor/README.md
+++ b/processor/README.md
@@ -153,15 +153,15 @@ Private endpoint used for server-to-server payment processing, for example to ch
 
 - transactionStatus
   - state: Result of the transaction. It can be `Pending`, `Failed` or `Completed`. `Pending` means the PSP accepted the charge but has not confirmed it yet - typical of payment methods that are settled asynchronously and may still be confirmed at a later point. This mock decides the outcome synchronously and never returns `Pending`; a real PSP integration built from this template is likely to.
-  - paymentId: Id of the commercetools Payment resource created for this charge, when available.
   - errors: List of errors, present when the payment was rejected.
+- paymentId: Id of the commercetools Payment resource created for this charge, when available.
 
 ```
 {
     transactionStatus: {
         state: "Pending|Failed|Completed",
-        paymentId: "<paymentId>",
         errors: [{ code: "PaymentRejected", message: "<message>" }]
-    }
+    },
+    paymentId: "<paymentId>"
 }
 ```

--- a/processor/README.md
+++ b/processor/README.md
@@ -55,7 +55,6 @@ Setup correct environment variables: check `processor/src/config/config.ts` for 
 Make sure commercetools client credential have at least the following permissions:
 
 * `manage_payments`
-* `manage_checkout_payment_intents`
 * `view_sessions`
 * `introspect_oauth_tokens`
 
@@ -128,3 +127,41 @@ Token can be found in response
 ```
 
 Use the token to authenticate requests protected by JWT: `Authorization: Bearer <token>`. 
+
+## APIs
+
+### Create transaction
+
+Private endpoint used for server-to-server payment processing, for example to charge a recurring order's billing cycle using a previously stored payment method. Unlike the other endpoints, it is not called from Checkout front-end but from a backend system. It is protected by `manage_project` and `manage_checkout_transactions` access rights of composable commerce OAuth2 token.
+
+#### Endpoint
+
+`POST /operations/transactions`
+
+#### Request Parameters
+
+- cartId: Id of the cart to charge.
+- checkoutTransactionItemId: Id of the checkout payment-transaction item this request is processing. The commercetools Payment created for this charge is linked to this value.
+- amount
+  - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5. It must match the currency and not exceed the outstanding amount of the cart, otherwise the request is rejected.
+  - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
+- paymentMethodId: Id of the previously stored payment method to charge.
+- idempotencyKey: Key used to make repeated requests for the same charge attempt idempotent. In a real PSP integration this would be forwarded to the PSP's own idempotency mechanism - this mock does not call a real PSP, so the value is accepted but unused.
+- type: Type of transaction to process. Currently only `Recurring` is supported.
+
+#### Response Parameters
+
+- transactionStatus
+  - state: Result of the transaction. It can be `Pending`, `Failed` or `Completed`. `Pending` means the PSP accepted the charge but has not confirmed it yet - typical of payment methods that are settled asynchronously and may still be confirmed at a later point. This mock decides the outcome synchronously and never returns `Pending`; a real PSP integration built from this template is likely to.
+  - paymentId: Id of the commercetools Payment resource created for this charge, when available.
+  - errors: List of errors, present when the payment was rejected.
+
+```
+{
+    transactionStatus: {
+        state: "Pending|Failed|Completed",
+        paymentId: "<paymentId>",
+        errors: [{ code: "PaymentRejected", message: "<message>" }]
+    }
+}
+```

--- a/processor/README.md
+++ b/processor/README.md
@@ -142,11 +142,15 @@ Private endpoint used for server-to-server payment processing, for example to ch
 
 - cartId: Id of the cart to charge.
 - checkoutTransactionItemId: Id of the checkout payment-transaction item this request is processing. The commercetools Payment created for this charge is linked to this value.
-- amount
+- paymentInterface (optional): Deprecated, do not use.
+- amount (optional)
   - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5. It must match the currency and not exceed the outstanding amount of the cart, otherwise the request is rejected.
   - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
-- paymentMethodId: Id of the previously stored payment method to charge.
-- idempotencyKey: Key used to make repeated requests for the same charge attempt idempotent. In a real PSP integration this would be forwarded to the PSP's own idempotency mechanism - this mock does not call a real PSP, so the value is accepted but unused.
+
+  When omitted, the cart's outstanding amount is charged instead, and no currency/amount validation against the cart is performed.
+- paymentMethodId: Id of the previously stored payment method to charge. Required to process the charge.
+- idempotencyKey (optional): Key used to make repeated requests for the same charge attempt idempotent. In a real PSP integration this would be forwarded to the PSP's own idempotency mechanism - this mock does not call a real PSP, so the value is accepted but unused.
+- futureOrderNumber (optional): Accepted but unused by this mock.
 - type: Type of transaction to process. Currently only `Recurring` is supported.
 
 #### Response Parameters

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -1,15 +1,17 @@
 import { Static, Type } from '@sinclair/typebox';
 
+const TransactionTypes = Type.Union([Type.Literal('Recurring')]);
+
 export const TransactionDraft = Type.Object({
   cartId: Type.String({ format: 'uuid' }),
-  paymentInterface: Type.String({ format: 'uuid' }),
-  amount: Type.Optional(
-    Type.Object({
-      centAmount: Type.Number(),
-      currencyCode: Type.String(),
-    }),
-  ),
-  futureOrderNumber: Type.Optional(Type.String()),
+  checkoutTransactionItemId: Type.String({ format: 'uuid' }),
+  amount: Type.Object({
+    centAmount: Type.Number(),
+    currencyCode: Type.String(),
+  }),
+  paymentMethodId: Type.String({ format: 'uuid' }),
+  idempotencyKey: Type.String(),
+  type: TransactionTypes,
 });
 
 const TransactionStatePending = Type.Literal('Pending', {
@@ -33,6 +35,7 @@ export const TransactionStatusState = Type.Union([
 export const TransactionResponse = Type.Object({
   transactionStatus: Type.Object({
     state: TransactionStatusState,
+    paymentId: Type.Optional(Type.String()),
     errors: Type.Array(
       Type.Object({
         code: Type.Literal('PaymentRejected'),

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -35,7 +35,6 @@ export const TransactionStatusState = Type.Union([
 export const TransactionResponse = Type.Object({
   transactionStatus: Type.Object({
     state: TransactionStatusState,
-    paymentId: Type.Optional(Type.String()),
     errors: Type.Array(
       Type.Object({
         code: Type.Literal('PaymentRejected'),
@@ -43,6 +42,7 @@ export const TransactionResponse = Type.Object({
       }),
     ),
   }),
+  paymentId: Type.Optional(Type.String()),
 });
 
 export type TransactionDraftDTO = Static<typeof TransactionDraft>;

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -5,12 +5,22 @@ const TransactionTypes = Type.Union([Type.Literal('Recurring')]);
 export const TransactionDraft = Type.Object({
   cartId: Type.String({ format: 'uuid' }),
   checkoutTransactionItemId: Type.String({ format: 'uuid' }),
-  amount: Type.Object({
-    centAmount: Type.Number(),
-    currencyCode: Type.String(),
-  }),
-  paymentMethodId: Type.String({ format: 'uuid' }),
-  idempotencyKey: Type.String(),
+  paymentInterface: Type.Optional(
+    Type.String({
+      format: 'uuid',
+      deprecated: true,
+      description: 'Deprecated: use checkoutTransactionItemId instead.',
+    }),
+  ),
+  amount: Type.Optional(
+    Type.Object({
+      centAmount: Type.Number(),
+      currencyCode: Type.String(),
+    }),
+  ),
+  paymentMethodId: Type.Optional(Type.String({ format: 'uuid' })),
+  idempotencyKey: Type.Optional(Type.String()),
+  futureOrderNumber: Type.Optional(Type.String()),
   type: TransactionTypes,
 });
 

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -1,11 +1,11 @@
 import {
   Cart,
+  ErrorInvalidField,
   ErrorInvalidOperation,
   ErrorRequiredField,
   healthCheckCommercetoolsPermissions,
   statusHandler,
   TransactionState,
-  TransactionType,
 } from '@commercetools/connect-payments-sdk';
 import {
   CancelPaymentRequest,
@@ -90,7 +90,6 @@ export class MockPaymentService extends AbstractPaymentService {
       'view_api_clients',
       'manage_orders',
       'introspect_oauth_tokens',
-      'manage_checkout_payment_intents',
       'manage_types',
     ];
 
@@ -592,25 +591,85 @@ export class MockPaymentService extends AbstractPaymentService {
   }
 
   public async handleTransaction(transactionDraft: TransactionDraftDTO): Promise<TransactionResponseDTO> {
-    const TRANSACTION_AUTHORIZATION_TYPE: TransactionType = 'Authorization';
-    const TRANSACTION_STATE_SUCCESS: TransactionState = 'Success';
-    const TRANSACTION_STATE_FAILURE: TransactionState = 'Failure';
+    if (transactionDraft.type === 'Recurring') {
+      return await this.handleTransactionRecurringType(transactionDraft);
+    }
 
-    const maxCentAmountIfSuccess = 10000;
+    throw new ErrorInvalidField('type', transactionDraft.type || 'not-provided', 'Recurring');
+  }
+
+  private async handleTransactionRecurringType(transactionDraft: TransactionDraftDTO): Promise<TransactionResponseDTO> {
+    if (!getStoredPaymentMethodsConfig().enabled) {
+      throw new ErrorInvalidOperation(
+        'The stored-payment-methods feature is disabled and thus cannot request a transaction using stored-payment-methods',
+      );
+    }
 
     const ctCart = await this.ctCartService.getCart({ id: transactionDraft.cartId });
 
-    let amountPlanned = transactionDraft.amount;
-    if (!amountPlanned) {
-      amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
+    if (!ctCart.customerId) {
+      throw new ErrorRequiredField('customerId', {
+        privateMessage: 'customerId is not set on the cart',
+        privateFields: {
+          cart: {
+            id: ctCart.id,
+          },
+          checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
+        },
+      });
     }
 
-    const isBelowSuccessStateThreshold = amountPlanned.centAmount < maxCentAmountIfSuccess;
+    const cartAmount = await this.ctCartService.getPaymentAmount({ cart: ctCart });
+
+    if (transactionDraft.amount.currencyCode !== cartAmount.currencyCode) {
+      throw new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, cartAmount.currencyCode);
+    }
+
+    if (transactionDraft.amount.centAmount > cartAmount.centAmount) {
+      throw new ErrorInvalidField(
+        'amount.centAmount',
+        String(transactionDraft.amount.centAmount),
+        `<= ${cartAmount.centAmount}`,
+      );
+    }
+
+    const paymentMethod = await this.ctPaymentMethodService.get({
+      id: transactionDraft.paymentMethodId,
+      customerId: ctCart.customerId,
+      paymentInterface: getStoredPaymentMethodsConfig().config.paymentInterface,
+      interfaceAccount: getStoredPaymentMethodsConfig().config.interfaceAccount,
+    });
+
+    if (!paymentMethod.token) {
+      throw new ErrorRequiredField('token', {
+        privateMessage: 'The "token" value is not set on the payment-method',
+        privateFields: {
+          cart: {
+            id: ctCart.id,
+          },
+          checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
+          paymentMethod: {
+            id: paymentMethod.id,
+          },
+        },
+      });
+    }
+
+    const amountPlanned = transactionDraft.amount;
 
     const newlyCreatedPayment = await this.ctPaymentService.createPayment({
       amountPlanned,
+      checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
       paymentMethodInfo: {
-        paymentInterface: transactionDraft.paymentInterface,
+        paymentInterface: 'mock',
+        token: {
+          value: paymentMethod.token.value,
+        },
+        ...(paymentMethod.method && { method: paymentMethod.method }),
+      },
+      customer: {
+        typeId: 'customer',
+        id: ctCart.customerId,
       },
     });
 
@@ -622,28 +681,28 @@ export class MockPaymentService extends AbstractPaymentService {
       paymentId: newlyCreatedPayment.id,
     });
 
-    const transactionState: TransactionState = isBelowSuccessStateThreshold
-      ? TRANSACTION_STATE_SUCCESS
-      : TRANSACTION_STATE_FAILURE;
+    const isAuthorized = this.simulatePspAuthorization(amountPlanned);
+    const transactionState: TransactionState = isAuthorized ? 'Success' : 'Failure';
 
     const pspReference = randomUUID().toString();
 
-    await this.ctPaymentService.updatePayment({
+    const updatedPayment = await this.ctPaymentService.updatePayment({
       id: newlyCreatedPayment.id,
       pspReference: pspReference,
       transaction: {
         amount: amountPlanned,
-        type: TRANSACTION_AUTHORIZATION_TYPE,
+        type: 'Authorization',
         state: transactionState,
         interactionId: pspReference,
       },
     });
 
-    if (isBelowSuccessStateThreshold) {
+    if (isAuthorized) {
       return {
         transactionStatus: {
           errors: [],
-          state: 'Pending',
+          state: 'Completed',
+          paymentId: updatedPayment.id,
         },
       };
     } else {
@@ -656,9 +715,19 @@ export class MockPaymentService extends AbstractPaymentService {
             },
           ],
           state: 'Failed',
+          paymentId: updatedPayment.id,
         },
       };
     }
+  }
+
+  /**
+   * Stands in for the actual request/response with the PSP. This mock decides the outcome
+   * deterministically from the charged amount, same as the rest of this mock service.
+   */
+  private simulatePspAuthorization(amount: { centAmount: number; currencyCode: string }): boolean {
+    const maxCentAmountIfSuccess = 10000;
+    return amount.centAmount < maxCentAmountIfSuccess;
   }
 
   private convertPaymentResultCode(resultCode: PaymentOutcome): string {

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -621,16 +621,34 @@ export class MockPaymentService extends AbstractPaymentService {
 
     const cartAmount = await this.ctCartService.getPaymentAmount({ cart: ctCart });
 
-    if (transactionDraft.amount.currencyCode !== cartAmount.currencyCode) {
-      throw new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, cartAmount.currencyCode);
+    if (transactionDraft.amount) {
+      if (transactionDraft.amount.currencyCode !== cartAmount.currencyCode) {
+        throw new ErrorInvalidField(
+          'amount.currencyCode',
+          transactionDraft.amount.currencyCode,
+          cartAmount.currencyCode,
+        );
+      }
+
+      if (transactionDraft.amount.centAmount > cartAmount.centAmount) {
+        throw new ErrorInvalidField(
+          'amount.centAmount',
+          String(transactionDraft.amount.centAmount),
+          `<= ${cartAmount.centAmount}`,
+        );
+      }
     }
 
-    if (transactionDraft.amount.centAmount > cartAmount.centAmount) {
-      throw new ErrorInvalidField(
-        'amount.centAmount',
-        String(transactionDraft.amount.centAmount),
-        `<= ${cartAmount.centAmount}`,
-      );
+    if (!transactionDraft.paymentMethodId) {
+      throw new ErrorRequiredField('paymentMethodId', {
+        privateMessage: 'paymentMethodId is not set on the transaction draft',
+        privateFields: {
+          cart: {
+            id: ctCart.id,
+          },
+          checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
+        },
+      });
     }
 
     const paymentMethod = await this.ctPaymentMethodService.get({
@@ -655,7 +673,7 @@ export class MockPaymentService extends AbstractPaymentService {
       });
     }
 
-    const amountPlanned = transactionDraft.amount;
+    const amountPlanned = transactionDraft.amount ?? cartAmount;
 
     const newlyCreatedPayment = await this.ctPaymentService.createPayment({
       amountPlanned,

--- a/processor/src/services/mock-payment.service.ts
+++ b/processor/src/services/mock-payment.service.ts
@@ -702,8 +702,8 @@ export class MockPaymentService extends AbstractPaymentService {
         transactionStatus: {
           errors: [],
           state: 'Completed',
-          paymentId: updatedPayment.id,
         },
+        paymentId: updatedPayment.id,
       };
     } else {
       return {
@@ -715,8 +715,8 @@ export class MockPaymentService extends AbstractPaymentService {
             },
           ],
           state: 'Failed',
-          paymentId: updatedPayment.id,
         },
+        paymentId: updatedPayment.id,
       };
     }
   }

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -437,8 +437,8 @@ describe('mock-payment.service', () => {
           transactionStatus: {
             errors: [],
             state: 'Completed',
-            paymentId: mockUpdatePaymentResult.id,
           },
+          paymentId: mockUpdatePaymentResult.id,
         });
       });
 
@@ -486,8 +486,8 @@ describe('mock-payment.service', () => {
               },
             ],
             state: 'Failed',
-            paymentId: mockUpdatePaymentResult.id,
           },
+          paymentId: mockUpdatePaymentResult.id,
         });
       });
     });

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -351,13 +351,13 @@ describe('mock-payment.service', () => {
         });
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
+          centAmount: transactionDraft.amount!.centAmount,
           currencyCode: 'USD',
           fractionDigits: 2,
         });
 
         expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(
-          new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, 'USD'),
+          new ErrorInvalidField('amount.currencyCode', transactionDraft.amount!.currencyCode, 'USD'),
         );
       });
 
@@ -371,17 +371,75 @@ describe('mock-payment.service', () => {
         });
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount - 1,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount - 1,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
 
         expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(
           new ErrorInvalidField(
             'amount.centAmount',
-            String(transactionDraft.amount.centAmount),
-            `<= ${transactionDraft.amount.centAmount - 1}`,
+            String(transactionDraft.amount!.centAmount),
+            `<= ${transactionDraft.amount!.centAmount - 1}`,
           ),
+        );
+      });
+
+      test('it should fall back to the cart amount, skipping currency/amount validation, when the draft does not have an amount set', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+
+        const cartAmount = { centAmount: 999, currencyCode: 'USD', fractionDigits: 2 };
+
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue(cartAmount);
+        jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(mockStoredPaymentMethod);
+        jest
+          .spyOn(DefaultPaymentService.prototype, 'createPayment')
+          .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
+        jest
+          .spyOn(DefaultCartService.prototype, 'addPayment')
+          .mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+        jest
+          .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+          .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
+
+        const transactionDraftWithoutAmount: TransactionDraftDTO = { ...transactionDraft, amount: undefined };
+
+        await mockPaymentService.handleTransaction(transactionDraftWithoutAmount);
+
+        expect(DefaultPaymentService.prototype.createPayment).toHaveBeenCalledWith(
+          expect.objectContaining({ amountPlanned: cartAmount }),
+        );
+      });
+
+      test('it should throw an ErrorRequiredField if the draft does not have a paymentMethodId set', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount!.centAmount,
+          currencyCode: transactionDraft.amount!.currencyCode,
+          fractionDigits: 2,
+        });
+
+        const transactionDraftWithoutPaymentMethodId: TransactionDraftDTO = {
+          ...transactionDraft,
+          paymentMethodId: undefined,
+        };
+
+        expect(mockPaymentService.handleTransaction(transactionDraftWithoutPaymentMethodId)).rejects.toThrow(
+          new ErrorRequiredField('paymentMethodId'),
         );
       });
 
@@ -395,8 +453,8 @@ describe('mock-payment.service', () => {
         });
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue({
@@ -417,8 +475,8 @@ describe('mock-payment.service', () => {
         });
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(mockStoredPaymentMethod);
@@ -460,8 +518,8 @@ describe('mock-payment.service', () => {
         });
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: failingTransactionDraft.amount.centAmount,
-          currencyCode: failingTransactionDraft.amount.currencyCode,
+          centAmount: failingTransactionDraft.amount!.centAmount,
+          currencyCode: failingTransactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(mockStoredPaymentMethod);

--- a/processor/test/mock-payment.service.spec.ts
+++ b/processor/test/mock-payment.service.spec.ts
@@ -17,9 +17,17 @@ import { MockPaymentService } from '../src/services/mock-payment.service';
 import * as FastifyContext from '../src/libs/fastify/context/context';
 import * as StatusHandler from '@commercetools/connect-payments-sdk/dist/api/handlers/status.handler';
 
-import { HealthCheckResult } from '@commercetools/connect-payments-sdk';
+import {
+  ErrorInvalidField,
+  ErrorInvalidOperation,
+  ErrorRequiredField,
+  HealthCheckResult,
+  PaymentMethod,
+} from '@commercetools/connect-payments-sdk';
+import { DefaultPaymentMethodService } from '@commercetools/connect-payments-sdk/dist/commercetools/services/ct-payment-method.service';
 import { PaymentMethodType, PaymentOutcome } from '../src/dtos/mock-payment.dto';
 import { TransactionDraftDTO } from '../src/dtos/operations/transaction.dto';
+import * as StoredPaymentMethodsConfig from '../src/config/stored-payment-methods.config';
 
 interface FlexibleConfig {
   [key: string]: string; // Adjust the type according to your config values
@@ -253,65 +261,234 @@ describe('mock-payment.service', () => {
   });
 
   describe('handleTransaction', () => {
-    test('should create the payment in CoCo and return it with a success state', async () => {
-      const createPaymentOpts: TransactionDraftDTO = {
-        cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
-        paymentInterface: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
-        amount: {
-          centAmount: 1000,
-          currencyCode: 'EUR',
-        },
-      };
+    const customerId = '0e2a18f3-9f3b-4cef-83ab-6d892c95a0a8';
+    const paymentMethodId = '997ff5fb-838b-4978-bf47-37a7de565820';
 
-      jest.spyOn(DefaultCartService.prototype, 'getCart').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
-      jest
-        .spyOn(DefaultPaymentService.prototype, 'createPayment')
-        .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
-      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
-      jest
-        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
-        .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
+    const transactionDraft: TransactionDraftDTO = {
+      cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
+      checkoutTransactionItemId: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
+      amount: {
+        centAmount: 1000,
+        currencyCode: 'EUR',
+      },
+      paymentMethodId,
+      idempotencyKey: 'idempotency-key-value',
+      type: 'Recurring',
+    };
 
-      const resultPromise = mockPaymentService.handleTransaction(createPaymentOpts);
-      expect(resultPromise).resolves.toStrictEqual({
-        transactionStatus: {
-          errors: [],
-          state: 'Pending',
-        },
-      });
+    const mockStoredPaymentMethod: PaymentMethod = {
+      id: paymentMethodId,
+      createdAt: '',
+      lastModifiedAt: '',
+      paymentMethodStatus: 'Active',
+      version: 1,
+      default: false,
+      token: {
+        value: 'mock-token-value',
+      },
+      method: 'card',
+    };
+
+    test('it should throw an ErrorInvalidField if the provided "type" value is unsupported', async () => {
+      const invalidTransactionDraft: TransactionDraftDTO = {
+        ...transactionDraft,
+        type: 'UnknownType',
+      } as unknown as TransactionDraftDTO;
+
+      expect(mockPaymentService.handleTransaction(invalidTransactionDraft)).rejects.toThrow(
+        new ErrorInvalidField('type', 'UnknownType', 'Recurring'),
+      );
     });
 
-    test('should create the payment in CoCo and return it with a failed state', async () => {
-      const createPaymentOpts: TransactionDraftDTO = {
-        cartId: 'dd4b7669-698c-4175-8e4c-bed178abfed3',
-        paymentInterface: '42251cfc-0660-4ab3-80f6-c32829aa7a8b',
-        amount: {
-          centAmount: 10000,
-          currencyCode: 'EUR',
-        },
-      };
+    test('it should throw an ErrorInvalidField if the "type" value is not provided', async () => {
+      const invalidTransactionDraft: TransactionDraftDTO = {
+        ...transactionDraft,
+        type: undefined,
+      } as unknown as TransactionDraftDTO;
 
-      jest.spyOn(DefaultCartService.prototype, 'getCart').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
-      jest
-        .spyOn(DefaultPaymentService.prototype, 'createPayment')
-        .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
-      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
-      jest
-        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
-        .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
+      expect(mockPaymentService.handleTransaction(invalidTransactionDraft)).rejects.toThrow(
+        new ErrorInvalidField('type', 'not-provided', 'Recurring'),
+      );
+    });
 
-      const resultPromise = mockPaymentService.handleTransaction(createPaymentOpts);
+    describe('Recurring', () => {
+      test('it should throw an ErrorInvalidOperation if the stored-payment-methods feature is not enabled', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: false,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
 
-      expect(resultPromise).resolves.toStrictEqual({
-        transactionStatus: {
-          errors: [
-            {
-              code: 'PaymentRejected',
-              message: `Payment '${mockGetPaymentResult.id}' has been rejected.`,
-            },
-          ],
-          state: 'Failed',
-        },
+        expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(ErrorInvalidOperation);
+      });
+
+      test('it should throw an ErrorRequiredField if the provided cart does not have a customerId set', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest
+          .spyOn(DefaultCartService.prototype, 'getCart')
+          .mockResolvedValue({ ...mockGetCartResult(), customerId: undefined });
+
+        expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(
+          new ErrorRequiredField('customerId'),
+        );
+      });
+
+      test('it should throw an ErrorInvalidField if the draft amount currency does not match the cart amount currency', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: 'USD',
+          fractionDigits: 2,
+        });
+
+        expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(
+          new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, 'USD'),
+        );
+      });
+
+      test('it should throw an ErrorInvalidField if the draft amount is greater than the cart amount', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount - 1,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
+
+        expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(
+          new ErrorInvalidField(
+            'amount.centAmount',
+            String(transactionDraft.amount.centAmount),
+            `<= ${transactionDraft.amount.centAmount - 1}`,
+          ),
+        );
+      });
+
+      test('it should throw an ErrorRequiredField if the paymentMethod referenced does not have a token value set', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
+        jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue({
+          ...mockStoredPaymentMethod,
+          token: undefined,
+        });
+
+        expect(mockPaymentService.handleTransaction(transactionDraft)).rejects.toThrow(new ErrorRequiredField('token'));
+      });
+
+      test('should create the payment in CoCo and return it with a Completed state', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
+        jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(mockStoredPaymentMethod);
+        jest
+          .spyOn(DefaultPaymentService.prototype, 'createPayment')
+          .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
+        jest
+          .spyOn(DefaultCartService.prototype, 'addPayment')
+          .mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+        jest
+          .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+          .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
+
+        const resultPromise = mockPaymentService.handleTransaction(transactionDraft);
+        expect(resultPromise).resolves.toStrictEqual({
+          transactionStatus: {
+            errors: [],
+            state: 'Completed',
+            paymentId: mockUpdatePaymentResult.id,
+          },
+        });
+      });
+
+      test('should create the payment in CoCo and return it with a Failed state', async () => {
+        const failingTransactionDraft: TransactionDraftDTO = {
+          ...transactionDraft,
+          amount: {
+            centAmount: 10000,
+            currencyCode: 'EUR',
+          },
+        };
+
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface: 'psp-template',
+            allowedPaymentMethods: [PaymentMethodType.CARD],
+          },
+        });
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue({ ...mockGetCartResult(), customerId });
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: failingTransactionDraft.amount.centAmount,
+          currencyCode: failingTransactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
+        jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(mockStoredPaymentMethod);
+        jest
+          .spyOn(DefaultPaymentService.prototype, 'createPayment')
+          .mockReturnValueOnce(Promise.resolve(mockGetPaymentResult));
+        jest
+          .spyOn(DefaultCartService.prototype, 'addPayment')
+          .mockReturnValueOnce(Promise.resolve(mockGetCartResult()));
+        jest
+          .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+          .mockReturnValue(Promise.resolve(mockUpdatePaymentResult));
+
+        const resultPromise = mockPaymentService.handleTransaction(failingTransactionDraft);
+
+        expect(resultPromise).resolves.toStrictEqual({
+          transactionStatus: {
+            errors: [
+              {
+                code: 'PaymentRejected',
+                message: `Payment '${mockGetPaymentResult.id}' has been rejected.`,
+              },
+            ],
+            state: 'Failed',
+            paymentId: mockUpdatePaymentResult.id,
+          },
+        });
       });
     });
   });


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3995

Add support to process server to server payments in order to enable Checkout to send payment requests for recurring orders.