### PR TITLE
fix(deps): bump pinned brace-expansion and js-yaml to patched versions

### DIFF
--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -3542,9 +3542,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4501,9 +4501,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5023,9 +5023,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/enabler/package.json
+++ b/enabler/package.json
@@ -34,9 +34,9 @@
     "@babel/core": "7.29.7",
     "path-to-regexp": "3.3.0",
     "lodash": "4.18.1",
-    "brace-expansion@^1": "1.1.17",
-    "brace-expansion@^2": "2.1.3",
+    "brace-expansion@^1": "1.1.18",
+    "brace-expansion@^2": "2.1.4",
     "picomatch": "2.3.2",
-    "js-yaml@^3.13.1": "3.15.0"
+    "js-yaml@^3.13.1": "3.15.1"
   }
 }

--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -1541,9 +1541,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4025,9 +4025,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7747,9 +7747,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8157,9 +8157,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/processor/package.json
+++ b/processor/package.json
@@ -68,11 +68,11 @@
     "@babel/core": "7.29.7",
     "@babel/runtime": "7.26.10",
     "@babel/runtime-corejs3": "7.26.10",
-    "brace-expansion@^1": "1.1.17",
-    "brace-expansion@^5": "5.0.8",
+    "brace-expansion@^1": "1.1.18",
+    "brace-expansion@^5": "5.0.9",
     "diff": "9.0.0",
     "flatted": "3.4.2",
     "minimatch": "3.1.5",
-    "js-yaml@^3.13.1": "3.15.0"
+    "js-yaml@^3.13.1": "3.15.1"
   }
 }


### PR DESCRIPTION
Our own overrides pinned the exact versions flagged by the advisories, which is why Dependabot reported it could not reach a non-vulnerable version. The patched releases were installable all along; no upstream conflict existed.

  brace-expansion  1.1.17 -> 1.1.18  (advisory: <1.1.18)
  brace-expansion  2.1.3  -> 2.1.4   (advisory: >=2.0.0 <2.1.4)
  brace-expansion  5.0.8  -> 5.0.9   (advisory: >=4.0.0 <5.0.9)
  js-yaml          3.15.0 -> 3.15.1  (advisory: >=3.0.0 <3.15.1)
  js-yaml          4.3.0  -> 4.3.1   (advisory: >=4.0.0 <4.3.1)

The js-yaml 4.3.0 issue in /processor was not in the Dependabot alerts; npm audit surfaced it. It had no override, just a stale lockfile entry, so only the lockfile needed correcting.

Lockfiles are patched in place (version/resolved/integrity only) rather than regenerated: these lockfiles are produced by Dependabot on Linux, and regenerating them on macOS strips the libc markers on @parcel/watcher-linux-* and prunes the @emnapi WASM fallback entries that CI's `npm ci` relies on.

npm audit reports 0 vulnerabilities in both workspaces; npm ci, build and tests pass (1 + 34 tests).